### PR TITLE
文章搜索后端接口+前端微更新

### DIFF
--- a/back-end/src/main/java/com/kingfar/blog/controller/ArticleController.java
+++ b/back-end/src/main/java/com/kingfar/blog/controller/ArticleController.java
@@ -3,12 +3,15 @@ package com.kingfar.blog.controller;
 import com.alibaba.fastjson.JSONObject;
 import com.kingfar.blog.entity.ArticleData;
 import com.kingfar.blog.entity.buffer.ArticleBuffer;
+import com.kingfar.blog.entity.response.ArticleResponse;
+import com.kingfar.blog.entity.response.Response;
 import com.kingfar.blog.service.ArticleService;
 import com.kingfar.blog.util.ArticleUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -22,29 +25,49 @@ public class ArticleController {
     ArticleService articleService;
 
     @PostMapping("/load")
-    Map load(@RequestBody JSONObject jsonObject) {
+    Response load(@RequestBody JSONObject jsonObject) {
         String pageIndex = jsonObject.getString("pageIndex");
         int currentPage = Integer.parseInt(pageIndex);
         ArticleBuffer buffer = ArticleUtils.getBuffer();
-        articleService.getResource();
+        try {
+            articleService.getResource();
+        } catch (Exception e) {
+            return new ArticleResponse(1, "failed to load resource", null);
+        }
         Map respMap = new HashMap(4);
         respMap.put("buffer-length", buffer.getBufferLen());
         respMap.put("page-length", buffer.getPageLen());
         respMap.put("current-page", buffer.getCurrentPage());
         respMap.put("articles", ArticleUtils.getPage(currentPage));
-        return respMap;
+        return new ArticleResponse(0, "success", respMap);
     }
 
     @PostMapping("/submit")
-    Map submit(@RequestBody ArticleData article) {
-        Map<String, String> reapMap = new HashMap<>(1);
+    ArticleResponse submit(@RequestBody ArticleData article) {
         try {
             articleService.submit(article);
         } catch (Exception e) {
             e.printStackTrace();
-            reapMap.put("msg", "failed to submit");
+            return new ArticleResponse(3, "failed to submit", null);
         }
-        reapMap.put("msg", "success");
-        return reapMap;
+        return new ArticleResponse(0, "success!", null);
+    }
+
+    @PostMapping("/search")
+    Response search(@RequestBody JSONObject jsonObject) {
+        String title = jsonObject.getString("key");
+        List<ArticleData> articles;
+        try {
+            articles = articleService.search(title);
+        } catch (Exception e) {
+            return new ArticleResponse(2, "no results matched", null);
+        }
+        ArticleBuffer buffer = ArticleUtils.getBuffer();
+        Map respMap = new HashMap(4);
+        respMap.put("buffer-length", articles.size());
+        respMap.put("page-length", buffer.getPageLen());
+        respMap.put("current-page", 1);
+        respMap.put("articles", articles);
+        return new ArticleResponse(0, "success!", respMap);
     }
 }

--- a/back-end/src/main/java/com/kingfar/blog/entity/response/ArticleResponse.java
+++ b/back-end/src/main/java/com/kingfar/blog/entity/response/ArticleResponse.java
@@ -1,0 +1,26 @@
+package com.kingfar.blog.entity.response;
+
+import com.kingfar.blog.entity.ArticleData;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author ZHANGKAIHENG
+ */
+@Data
+public class ArticleResponse extends Response {
+    Map<String, Object> respMap;
+
+    @Override
+    protected int groupCode() {
+        return 3;
+    }
+
+    public ArticleResponse(int code, String msg, Map<String, Object> respMap) {
+        super(code, msg);
+
+        this.respMap = respMap;
+    }
+}

--- a/back-end/src/main/java/com/kingfar/blog/mapper/ArticleMapper.java
+++ b/back-end/src/main/java/com/kingfar/blog/mapper/ArticleMapper.java
@@ -19,4 +19,6 @@ public interface ArticleMapper {
     int countArticles();
 
     int insertArticle(@Param("title") String title, @Param("content") String content, @Param("author") String author, @Param("ctime") Date ctime);
+
+    List<ArticleData> search(String title);
 }

--- a/back-end/src/main/java/com/kingfar/blog/service/ArticleService.java
+++ b/back-end/src/main/java/com/kingfar/blog/service/ArticleService.java
@@ -2,6 +2,8 @@ package com.kingfar.blog.service;
 
 import com.kingfar.blog.entity.ArticleData;
 
+import java.util.List;
+
 /**
  * @author ZHANGKAIHENG
  */
@@ -9,4 +11,6 @@ public interface ArticleService {
     void getResource();
 
     void submit(ArticleData article);
+
+    List<ArticleData> search(String title);
 }

--- a/back-end/src/main/java/com/kingfar/blog/service/ArticleServiceImpl.java
+++ b/back-end/src/main/java/com/kingfar/blog/service/ArticleServiceImpl.java
@@ -32,4 +32,9 @@ public class ArticleServiceImpl implements ArticleService {
         ArticleUtils.submit(article);
         articleMapper.insertArticle(article.getTitle(), article.getContent(), article.getAuthor(), date);
     }
+
+    @Override
+    public List<ArticleData> search(String title) {
+        return articleMapper.search(title);
+    }
 }

--- a/back-end/src/main/resources/application.yml
+++ b/back-end/src/main/resources/application.yml
@@ -2,6 +2,7 @@ mybatis:
   type-aliases-package: com.kingfar.blog.entity
   mapper-locations: classpath:mapper/*.xml
   configuration:
+#    open this annotation only when test / debug
 #    log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
     map-underscope-to-camel-case: true
 

--- a/back-end/src/main/resources/mapper/AriticleMapper.xml
+++ b/back-end/src/main/resources/mapper/AriticleMapper.xml
@@ -16,4 +16,8 @@
     <insert id="insertArticle">
         INSERT INTO t_article(title, content, author, ctime) VALUE (#{title}, #{content}, #{author}, #{ctime})
     </insert>
+
+    <select id="search" parameterType="String" resultType="com.kingfar.blog.entity.ArticleData">
+        SELECT * FROM t_article WHERE title LIKE concat('%',#{title},'%') ORDER BY ctime DESC
+    </select>
 </mapper>

--- a/back-end/src/test/java/com/kingfar/blog/mapper/ArticleMapperTest.java
+++ b/back-end/src/test/java/com/kingfar/blog/mapper/ArticleMapperTest.java
@@ -28,4 +28,9 @@ class ArticleMapperTest {
         Date date = new Date(System.currentTimeMillis());
         System.out.println(articleMapper.insertArticle("Test submit", "can I submit this article?", "ZHANG", date));
     }
+
+    @Test
+    void testSearch() {
+        System.out.println(articleMapper.search("a"));
+    }
 }

--- a/front-end/src/components/mainpage_components/ArticleList.vue
+++ b/front-end/src/components/mainpage_components/ArticleList.vue
@@ -58,17 +58,24 @@ export default {
           pageIndex: store.state.pageIndex
         })
         .then(res => {
-          // data => store
-          store.commit('setArticle', res)
-          // data => page
-          that.articleBuf = res.data['articles']
-          that.pageNum =
-            parseInt(res.data['buffer-length'] / res.data['page-length']) + 1
-          that.pageSize = res.data['page-length']
-          that.articleNum = res.data['buffer-length']
-          that.pageIndex = res.data['current-page']
+          if(res.data['code'] === 300) {
+            let respMap = res.data['respMap']
+            // data => store
+            store.commit('setArticle', respMap)
+            // data => page
+            that.articleBuf = respMap['articles']
+            that.pageNum =
+              parseInt(respMap['buffer-length'] / respMap['page-length']) + 1
+            that.pageSize = respMap['page-length']
+            that.articleNum = respMap['buffer-length']
+            that.pageIndex = respMap['current-page']
+          } else {
+            this.$message({
+              message: res.data['msg'],
+              type: 'error'
+            })
+          }
         })
-        console.log(store.state)
     },
 
     setArticle(article) {

--- a/front-end/src/store/mutations.js
+++ b/front-end/src/store/mutations.js
@@ -46,17 +46,17 @@ const mutations = {
     localStorage.setItem('ctime', user.ctime)
   },
 
-  setArticle(state, res) {
-    state.articleBuf = res.data['articles']
+  setArticle(state, respMap) {
+    state.articleBuf = respMap['articles']
     localStorage.setItem("articleBuf", JSON.stringify(state.articleBuf))
     state.pageNum =
-      parseInt(res.data['buffer-length'] / res.data['page-length']) + 1
+      parseInt(respMap['buffer-length'] / respMap['page-length']) + 1
     localStorage.setItem('pageNum', state.pageNum)
-    state.pageSize = res.data['page-length']
+    state.pageSize = respMap['page-length']
     localStorage.setItem('pageSize', state.pageSize)
-    state.articleNum = res.data['buffer-length']
+    state.articleNum = respMap['buffer-length']
     localStorage.setItem('articleNum', state.articleNum)
-    state.pageIndex = res.data['current-page']
+    state.pageIndex = respMap['current-page']
     localStorage.setItem('pageIndex', state.pageIndex)
   },
 


### PR DESCRIPTION
- 增加了Response类的子类ArticleResponse
- 重构了ArticleController，现在返回的是封装后的ArticleResponse
- 完成了文章搜索接口，现在可按用户给出的标题模糊匹配（不提供松散匹配）
- 根据后端接口的返回响应修改了前端异步请求的细节